### PR TITLE
Initialize monorepo structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# POS & Web CMS Monorepo
+
+This repository contains the source code for the POS Frontend and CMS Web applications, along with shared packages.
+
+## Structure
+
+- **apps/pos-frontend** – Next.js application for the Point of Sale interface.
+- **apps/cms-web** – Next.js application for the admin dashboard.
+- **packages/ui** – Shared React UI components.
+- **packages/types** – Shared TypeScript type definitions.
+- **packages/utils** – Shared utility functions.
+
+Each Next.js app is configured for static export and uses client-side Supabase API calls.

--- a/apps/cms-web/lib/supabase.ts
+++ b/apps/cms-web/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/apps/cms-web/next-env.d.ts
+++ b/apps/cms-web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/cms-web/next.config.js
+++ b/apps/cms-web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+};
+
+module.exports = nextConfig;

--- a/apps/cms-web/package.json
+++ b/apps/cms-web/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "cms-web",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build && next export",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.0.0",
+    "next": "^14.0.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5.2.0"
+  }
+}

--- a/apps/cms-web/pages/index.tsx
+++ b/apps/cms-web/pages/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const HomePage: React.FC = () => {
+  return <div className="p-4">CMS Web</div>;
+};
+
+export default HomePage;

--- a/apps/cms-web/postcss.config.js
+++ b/apps/cms-web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/cms-web/tailwind.config.js
+++ b/apps/cms-web/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    '../../packages/ui/src/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/apps/cms-web/tsconfig.json
+++ b/apps/cms-web/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "paths": {
+      "@ui/*": ["../../packages/ui/src/*"],
+      "@types/*": ["../../packages/types/src/*"],
+      "@utils/*": ["../../packages/utils/src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/apps/pos-frontend/lib/supabase.ts
+++ b/apps/pos-frontend/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/apps/pos-frontend/next-env.d.ts
+++ b/apps/pos-frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/pos-frontend/next.config.js
+++ b/apps/pos-frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+};
+
+module.exports = nextConfig;

--- a/apps/pos-frontend/package.json
+++ b/apps/pos-frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "pos-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build && next export",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.0.0",
+    "next": "^14.0.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5.2.0"
+  }
+}

--- a/apps/pos-frontend/pages/index.tsx
+++ b/apps/pos-frontend/pages/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const HomePage: React.FC = () => {
+  return <div className="p-4">POS Frontend</div>;
+};
+
+export default HomePage;

--- a/apps/pos-frontend/postcss.config.js
+++ b/apps/pos-frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/pos-frontend/tailwind.config.js
+++ b/apps/pos-frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    '../../packages/ui/src/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/apps/pos-frontend/tsconfig.json
+++ b/apps/pos-frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "paths": {
+      "@ui/*": ["../../packages/ui/src/*"],
+      "@types/*": ["../../packages/types/src/*"],
+      "@utils/*": ["../../packages/utils/src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "shopflow-monorepo",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "dev:pos": "npm --workspace apps/pos-frontend run dev",
+    "dev:cms": "npm --workspace apps/cms-web run dev"
+  }
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@shopflow/types",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "private": true
+}

--- a/packages/types/src/Order.ts
+++ b/packages/types/src/Order.ts
@@ -1,0 +1,7 @@
+import { Product } from './Product';
+
+export interface Order {
+  id: string;
+  items: Product[];
+  total: number;
+}

--- a/packages/types/src/Product.ts
+++ b/packages/types/src/Product.ts
@@ -1,0 +1,5 @@
+export interface Product {
+  id: string;
+  name: string;
+  price: number;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,2 @@
+export * from './Product';
+export * from './Order';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@shopflow/ui",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0"
+  }
+}

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+}
+
+export const Button: React.FC<ButtonProps> = ({ label, ...props }) => (
+  <button className="px-4 py-2 bg-blue-500 text-white rounded" {...props}>
+    {label}
+  </button>
+);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Button';

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@shopflow/utils",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "private": true
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,2 @@
+export const formatCurrency = (value: number): string =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- bootstrap monorepo with `apps` and `packages` folders
- add Next.js apps (`pos-frontend` and `cms-web`)
- add shared `ui`, `types` and `utils` packages
- configure workspaces and base TypeScript settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872c981b488832ca7e918343d8d42dc