### PR TITLE
Add basic management pages for POS

### DIFF
--- a/apps/pos-frontend/pages/_document.tsx
+++ b/apps/pos-frontend/pages/_document.tsx
@@ -1,0 +1,17 @@
+import { Html, Head, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html lang="th">
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#2B6CB0" />
+        <link rel="manifest" href="/manifest.json" />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/apps/pos-frontend/pages/customers/index.tsx
+++ b/apps/pos-frontend/pages/customers/index.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+import {
+  Box,
+  VStack,
+  HStack,
+  Heading,
+  Text,
+  Button,
+  Icon,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Avatar,
+  Badge,
+  Card,
+  CardBody,
+  SimpleGrid,
+} from "@chakra-ui/react";
+import { FiUserPlus, FiDownload } from "react-icons/fi";
+import { POSLayout } from "../../components";
+
+const mockCustomers = [
+  {
+    id: "CUST-001",
+    name: "นายสมชาย ใจดี",
+    email: "somchai@example.com",
+    phone: "081-234-5678",
+    address: "123 ถนนสุขุมวิท แขวงคลองเตย เขตคลองเตย กรุงเทพฯ 10110",
+    totalOrders: 5,
+    totalSpent: 2750,
+    status: "active",
+  },
+  {
+    id: "CUST-002",
+    name: "นางสาวสมหญิง รักดี",
+    email: "somying@example.com",
+    phone: "082-345-6789",
+    address: "456 ถนนราชดำริ แขวงลุมพินี เขตปทุมวัน กรุงเทพฯ 10330",
+    totalOrders: 3,
+    totalSpent: 1890,
+    status: "vip",
+  },
+];
+
+const getStatusColor = (status: string) => {
+  switch (status) {
+    case "active":
+      return "green";
+    case "vip":
+      return "purple";
+    default:
+      return "gray";
+  }
+};
+
+const CustomersPage = () => {
+  const [customers] = useState(mockCustomers);
+  const totalCustomers = customers.length;
+  const totalRevenue = customers.reduce((s, c) => s + c.totalSpent, 0);
+
+  return (
+    <POSLayout title="ลูกค้า">
+      <VStack spacing={6} align="stretch">
+        <HStack justify="space-between">
+          <Heading size="lg">ลูกค้า</Heading>
+          <HStack>
+            <Button leftIcon={<Icon as={FiDownload} />} variant="outline">
+              ส่งออก
+            </Button>
+            <Button colorScheme="blue" leftIcon={<Icon as={FiUserPlus} />}>
+              เพิ่มลูกค้า
+            </Button>
+          </HStack>
+        </HStack>
+
+        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
+          <Card>
+            <CardBody>
+              <VStack>
+                <Text>ลูกค้าทั้งหมด</Text>
+                <Heading size="md">{totalCustomers}</Heading>
+              </VStack>
+            </CardBody>
+          </Card>
+          <Card>
+            <CardBody>
+              <VStack>
+                <Text>ยอดซื้อรวม</Text>
+                <Heading size="md">฿{totalRevenue.toLocaleString()}</Heading>
+              </VStack>
+            </CardBody>
+          </Card>
+        </SimpleGrid>
+
+        <Card>
+          <CardBody>
+            <Table variant="simple">
+              <Thead>
+                <Tr>
+                  <Th>ลูกค้า</Th>
+                  <Th>ติดต่อ</Th>
+                  <Th isNumeric>คำสั่งซื้อ</Th>
+                  <Th isNumeric>ยอดซื้อ</Th>
+                  <Th>สถานะ</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {customers.map((c) => (
+                  <Tr key={c.id}>
+                    <Td>
+                      <HStack>
+                        <Avatar size="sm" name={c.name} />
+                        <Text>{c.name}</Text>
+                      </HStack>
+                    </Td>
+                    <Td>
+                      <VStack align="start" spacing={0} fontSize="sm">
+                        <Text>{c.email}</Text>
+                        <Text>{c.phone}</Text>
+                      </VStack>
+                    </Td>
+                    <Td isNumeric>{c.totalOrders}</Td>
+                    <Td isNumeric>฿{c.totalSpent.toLocaleString()}</Td>
+                    <Td>
+                      <Badge colorScheme={getStatusColor(c.status)}>{c.status}</Badge>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </CardBody>
+        </Card>
+      </VStack>
+    </POSLayout>
+  );
+};
+
+export default CustomersPage;

--- a/apps/pos-frontend/pages/index.tsx
+++ b/apps/pos-frontend/pages/index.tsx
@@ -74,24 +74,43 @@ export default function HomePage() {
 
         {/* Quick Action Cards */}
         <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={6}>
-          <POSCard variant="elevated" interactive>
-            <VStack spacing={4}>
-              <Heading size="md" color="primary.600">
-                🛒 Sales Terminal
-              </Heading>
-              <Text textAlign="center" color="gray.600">
-                Start selling products and manage transactions
-              </Text>
-              <TouchButton
-                variant="primary"
-                size="lg"
-                width="full"
-                onClick={() => router.push("/sales")}
-              >
-                Start Sales
-              </TouchButton>
-            </VStack>
-          </POSCard>
+        <POSCard variant="elevated" interactive>
+          <VStack spacing={4}>
+            <Heading size="md" color="primary.600">
+              🛒 Sales Terminal
+            </Heading>
+            <Text textAlign="center" color="gray.600">
+              Start selling products and manage transactions
+            </Text>
+            <TouchButton
+              variant="primary"
+              size="lg"
+              width="full"
+              onClick={() => router.push("/sales")}
+            >
+              Start Sales
+            </TouchButton>
+          </VStack>
+        </POSCard>
+
+        <POSCard variant="elevated" interactive>
+          <VStack spacing={4}>
+            <Heading size="md" color="teal.600">
+              🛍️ Products
+            </Heading>
+            <Text textAlign="center" color="gray.600">
+              Manage product listings and pricing
+            </Text>
+            <TouchButton
+              variant="primary"
+              size="lg"
+              width="full"
+              onClick={() => router.push("/products")}
+            >
+              Manage Products
+            </TouchButton>
+          </VStack>
+        </POSCard>
 
           <POSCard variant="elevated" interactive>
             <VStack spacing={4}>
@@ -105,7 +124,7 @@ export default function HomePage() {
                 variant="primary"
                 size="lg"
                 width="full"
-                onClick={() => handleQuickAction("inventory")}
+                onClick={() => router.push("/inventory")}
               >
                 View Inventory
               </TouchButton>
@@ -124,7 +143,7 @@ export default function HomePage() {
                 variant="warning"
                 size="lg"
                 width="full"
-                onClick={() => handleQuickAction("reports")}
+                onClick={() => router.push("/reports")}
               >
                 View Reports
               </TouchButton>
@@ -143,7 +162,7 @@ export default function HomePage() {
                 variant="secondary"
                 size="lg"
                 width="full"
-                onClick={() => handleQuickAction("customers")}
+                onClick={() => router.push("/customers")}
               >
                 Manage Customers
               </TouchButton>
@@ -162,7 +181,7 @@ export default function HomePage() {
                 variant="warning"
                 size="lg"
                 width="full"
-                onClick={() => handleQuickAction("settings")}
+                onClick={() => router.push("/settings")}
               >
                 System Settings
               </TouchButton>

--- a/apps/pos-frontend/pages/inventory/index.tsx
+++ b/apps/pos-frontend/pages/inventory/index.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import {
+  VStack,
+  HStack,
+  Heading,
+  Text,
+  Button,
+  Icon,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Badge,
+  Card,
+  CardBody,
+  SimpleGrid,
+} from "@chakra-ui/react";
+import { FiPlus, FiAlertTriangle } from "react-icons/fi";
+import { POSLayout } from "../../components";
+import { mockProducts } from "../../lib/sales";
+
+const InventoryPage = () => {
+  const [products] = useState(mockProducts);
+  const lowStock = products.filter((p) => p.stock <= 5);
+
+  return (
+    <POSLayout title="สต็อก">
+      <VStack spacing={6} align="stretch">
+        <HStack justify="space-between">
+          <Heading size="lg">สต็อกสินค้า</Heading>
+          <Button colorScheme="blue" leftIcon={<Icon as={FiPlus} />}>ปรับสต็อก</Button>
+        </HStack>
+
+        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
+          <Card>
+            <CardBody>
+              <VStack>
+                <Text>สินค้าทั้งหมด</Text>
+                <Heading size="md">{products.length}</Heading>
+              </VStack>
+            </CardBody>
+          </Card>
+          <Card>
+            <CardBody>
+              <VStack>
+                <Text>สินค้าใกล้หมด</Text>
+                <Heading size="md" color="red.500">{lowStock.length}</Heading>
+              </VStack>
+            </CardBody>
+          </Card>
+        </SimpleGrid>
+
+        <Card>
+          <CardBody>
+            <Table variant="simple" size="sm">
+              <Thead>
+                <Tr>
+                  <Th>สินค้า</Th>
+                  <Th isNumeric>คงเหลือ</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {lowStock.map((p) => (
+                  <Tr key={p.id}>
+                    <Td>{p.name}</Td>
+                    <Td isNumeric>
+                      <Badge colorScheme="red">{p.stock}</Badge>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </CardBody>
+        </Card>
+      </VStack>
+    </POSLayout>
+  );
+};
+
+export default InventoryPage;

--- a/apps/pos-frontend/pages/products/index.tsx
+++ b/apps/pos-frontend/pages/products/index.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import {
+  VStack,
+  HStack,
+  Heading,
+  Text,
+  Button,
+  Icon,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Badge,
+  Card,
+  CardBody,
+  SimpleGrid,
+} from "@chakra-ui/react";
+import { FiPlus, FiTag } from "react-icons/fi";
+import { POSLayout } from "../../components";
+import { mockProducts } from "../../lib/sales";
+
+const getStatusColor = (stock: number, min = 1) => {
+  return stock <= min ? "red" : "green";
+};
+
+const ProductsPage = () => {
+  const [products] = useState(mockProducts);
+
+  return (
+    <POSLayout title="สินค้า">
+      <VStack spacing={6} align="stretch">
+        <HStack justify="space-between">
+          <Heading size="lg">สินค้า</Heading>
+          <HStack>
+            <Button colorScheme="blue" leftIcon={<Icon as={FiPlus} />}>เพิ่มสินค้า</Button>
+            <Button variant="outline" leftIcon={<Icon as={FiTag} />}>หมวดหมู่</Button>
+          </HStack>
+        </HStack>
+
+        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
+          <Card>
+            <CardBody>
+              <VStack>
+                <Text>จำนวนสินค้า</Text>
+                <Heading size="md">{products.length}</Heading>
+              </VStack>
+            </CardBody>
+          </Card>
+        </SimpleGrid>
+
+        <Card>
+          <CardBody>
+            <Table variant="simple" size="sm">
+              <Thead>
+                <Tr>
+                  <Th>ชื่อสินค้า</Th>
+                  <Th>หมวดหมู่</Th>
+                  <Th isNumeric>ราคา</Th>
+                  <Th isNumeric>สต็อก</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {products.map((p) => (
+                  <Tr key={p.id}>
+                    <Td>{p.name}</Td>
+                    <Td>{p.category}</Td>
+                    <Td isNumeric>{p.price.toFixed(2)}</Td>
+                    <Td isNumeric>
+                      <Badge colorScheme={getStatusColor(p.stock)}>{p.stock}</Badge>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </CardBody>
+        </Card>
+      </VStack>
+    </POSLayout>
+  );
+};
+
+export default ProductsPage;

--- a/apps/pos-frontend/pages/reports/index.tsx
+++ b/apps/pos-frontend/pages/reports/index.tsx
@@ -1,0 +1,42 @@
+import {
+  VStack,
+  HStack,
+  Heading,
+  Text,
+  Card,
+  CardBody,
+  SimpleGrid,
+} from "@chakra-ui/react";
+import { POSLayout } from "../../components";
+
+const ReportsPage = () => {
+  const stats = [
+    { label: "ยอดขายวันนี้", value: 2543.75, color: "green" },
+    { label: "จำนวนคำสั่งซื้อ", value: 47, color: "blue" },
+    { label: "กำไรประมาณ", value: 650.5, color: "purple" },
+  ];
+
+  return (
+    <POSLayout title="รายงาน">
+      <VStack spacing={6} align="stretch">
+        <Heading size="lg">รายงานยอดขาย</Heading>
+        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
+          {stats.map((s) => (
+            <Card key={s.label}>
+              <CardBody>
+                <VStack>
+                  <Text>{s.label}</Text>
+                  <Heading size="md" color={`${s.color}.500`}>
+                    {s.value.toLocaleString()}
+                  </Heading>
+                </VStack>
+              </CardBody>
+            </Card>
+          ))}
+        </SimpleGrid>
+      </VStack>
+    </POSLayout>
+  );
+};
+
+export default ReportsPage;

--- a/apps/pos-frontend/pages/settings/index.tsx
+++ b/apps/pos-frontend/pages/settings/index.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import {
+  VStack,
+  HStack,
+  Heading,
+  Text,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Switch,
+  Card,
+  CardBody,
+} from "@chakra-ui/react";
+import { POSLayout } from "../../components";
+
+const SettingsPage = () => {
+  const [loading, setLoading] = useState(false);
+
+  const handleSave = () => {
+    setLoading(true);
+    setTimeout(() => setLoading(false), 800);
+  };
+
+  return (
+    <POSLayout title="ตั้งค่า">
+      <VStack spacing={6} align="stretch">
+        <Heading size="lg">การตั้งค่า</Heading>
+        <Card>
+          <CardBody>
+            <VStack spacing={4} align="stretch">
+              <FormControl>
+                <FormLabel>ชื่อร้านค้า</FormLabel>
+                <Input defaultValue="ShopFlow" />
+              </FormControl>
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0">โหมดพัฒนา</FormLabel>
+                <Switch />
+              </FormControl>
+              <HStack justify="flex-end">
+                <Button colorScheme="blue" isLoading={loading} onClick={handleSave}>
+                  บันทึก
+                </Button>
+              </HStack>
+            </VStack>
+          </CardBody>
+        </Card>
+      </VStack>
+    </POSLayout>
+  );
+};
+
+export default SettingsPage;

--- a/apps/pos-frontend/public/manifest.json
+++ b/apps/pos-frontend/public/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "ShopFlow POS",
+  "short_name": "ShopFlow",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#2B6CB0",
+  "icons": []
+}


### PR DESCRIPTION
## Summary
- add customer, product, inventory, report and settings pages
- support mobile meta tags and manifest
- update home quick actions to link to new features

## Testing
- `npm --workspace apps/pos-frontend run build` *(fails: ReactNode type error)*

------
https://chatgpt.com/codex/tasks/task_e_6877ee370d9c832ca6c9727e0326a5ca